### PR TITLE
Adding parallelization to fit_uv

### DIFF
--- a/pdspy/interferometry/fit_model.py
+++ b/pdspy/interferometry/fit_model.py
@@ -74,7 +74,7 @@ def fit_model(data, funct='point', max_size=numpy.inf, \
                            logl_args=(x, y, z, zerr, funct, nparams,
                                       primary_beam, data.freq.mean()),
                            ptform_args=(funct, nparams,xlim, ylim, max_size, 
-                                        min_separation, image_rms)
+                                        min_separation, image_rms)):
         sampler = dynesty.NestedSampler(pool.loglike, pool.prior_transform, ndim=ndim,
                                         nlive=nlive, bound='multi', walks=nsteps, 
                                         periodic=periodic, pool=pool)

--- a/pdspy/interferometry/fit_model.py
+++ b/pdspy/interferometry/fit_model.py
@@ -74,7 +74,7 @@ def fit_model(data, funct='point', max_size=numpy.inf, \
                            logl_args=(x, y, z, zerr, funct, nparams,
                                       primary_beam, data.freq.mean()),
                            ptform_args=(funct, nparams,xlim, ylim, max_size, 
-                                        min_separation, image_rms)):
+                                        min_separation, image_rms)) as pool:
         sampler = dynesty.NestedSampler(pool.loglike, pool.prior_transform, ndim=ndim,
                                         nlive=nlive, bound='multi', walks=nsteps, 
                                         periodic=periodic, pool=pool)


### PR DESCRIPTION
When calling gaussian_model, you can do

```py
...
ncores = 10 # of processes to start, usually 2x the number of physical cores
uv.fit_models(...,  ncores=ncores)
```
This will greatly speed up the fit_models. For simple 1-2 gaussians it doesn't make too much difference but 4 gaussians, the fits were taking >10 hours

This still isn't the most efficient as at the start of the cycle all the cores specified are used and then at end of every cycle you will have most of the cores waiting on just a couple to finish, but the bottleneck is now at dynesty implementation of MP.